### PR TITLE
Make endpoints require "user" role

### DIFF
--- a/src/main/java/de/szut/lf8_starter/security/KeycloakSecurityConfig.java
+++ b/src/main/java/de/szut/lf8_starter/security/KeycloakSecurityConfig.java
@@ -1,28 +1,24 @@
 package de.szut.lf8_starter.security;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
-import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
-import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Configuration
 @EnableWebSecurity
@@ -59,7 +55,13 @@ class KeycloakSecurityConfig {
                         new AntPathRequestMatcher("/swagger-ui/**"),
                         new AntPathRequestMatcher("/v3/api-docs/**"))
                 .permitAll()
-                .requestMatchers(new AntPathRequestMatcher("/hello/**"))
+                // Add the new endpoints requiring "user" role here
+                .requestMatchers(
+                        new AntPathRequestMatcher("/hello/**"),
+                        new AntPathRequestMatcher("/qualifications/**"),
+                        new AntPathRequestMatcher("/employee/**"),
+                        new AntPathRequestMatcher("/customer/**"),
+                        new AntPathRequestMatcher("/projects/**"))
                 .hasRole("user")
                 .requestMatchers(new AntPathRequestMatcher("/roles"))
                 .authenticated()
@@ -69,6 +71,7 @@ class KeycloakSecurityConfig {
                 .authenticated()).oauth2ResourceServer(spec -> spec.jwt(Customizer.withDefaults()));
         return http.build();
     }
+
 
     @Bean
     public JwtAuthenticationConverter jwtAuthenticationConverter() {

--- a/src/test/java/de/szut/lf8_starter/project/ProjectGetIT.java
+++ b/src/test/java/de/szut/lf8_starter/project/ProjectGetIT.java
@@ -6,12 +6,13 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class ProjectGetIT extends AbstractIntegrationTest {
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "user")
     void testGetProjects_Pagination() throws Exception {
         // Test pagination
         this.mockMvc.perform(get("/projects?page=0&size=50"))
@@ -21,24 +22,26 @@ public class ProjectGetIT extends AbstractIntegrationTest {
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "user")
     void testGetProjects_Filtering() throws Exception {
         // Test filtering
         this.mockMvc.perform(get("/projects")
-                .param("managerId", "1")
-                .param("customerId", "1"))
+                        .param("managerId", "1")
+                        .param("customerId", "1"))
                 .andExpect(status().isOk());
     }
 
+    // no user role
     @Test
+    @WithMockUser
     void testGetProjects_Unauthorized() throws Exception {
         // Test unauthorized access
         this.mockMvc.perform(get("/projects"))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().is4xxClientError());
     }
 
     @Test
-    @WithMockUser
+    @WithMockUser(roles = "user")
     void testGetProjects_Sorting() throws Exception {
         // Test sorting
         this.mockMvc.perform(get("/projects"))


### PR DESCRIPTION
Um die Aufgabenstellung zu zitieren:

>Das Projekt ist bereits im vorhandenen Keycloak-Service registriert. In der Datei KeycloakSecurityConfig muss lediglich Code ergänzt werden, der die Endpunkte, die ihr implementiert, absichert, d.h. prüft, ob der Anfragende die Rolle “user” besitzt.